### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,8 @@ dependency (this library uses [semantic versioning](http://semver.org/)):
 
     gem 'aws-sdk-core', '~> 2.0'
 
-Until the final release becomes available on Rubygems, you can bundle the latest
-version from this repository by using this in your Gemfile:
-
-    gem 'aws-sdk-core', git: 'git://github.com/aws/aws-sdk-core-ruby'
+Until the final release becomes available on Rubygems, leave off the version
+dependency in your Gemfile so Bundler can find it.
 
 **Note:** AWS SDK Core requires Ruby 1.9.3+.
 


### PR DESCRIPTION
Using the original bundler example on my Mac returned

`Could not find gem 'aws-sdk-core (~> 2.0) ruby' in the gems available on this machine.`

Running `gem list aws-sdk-core --remote` against https://rubygems.org returned no results.

Thought this might be a good stopgap?
