### PR TITLE
Don't blow the stack on JRuby

### DIFF
--- a/vendor/seahorse/lib/seahorse/client/configuration.rb
+++ b/vendor/seahorse/lib/seahorse/client/configuration.rb
@@ -54,7 +54,7 @@ module Seahorse
       # @api private
       Defaults = Class.new(Array) do
         def each(&block)
-          reverse.each(&block)
+          reverse.to_a.each(&block)
         end
       end
 


### PR DESCRIPTION
The Defaults class was making an assumption about the return value of
Array#reverse that doesn't hold up on JRuby nor will it on Ruby 2.1
once that comes out. Calling to_a after reverse ensures we have an
actual Array object so we don't recursively call the overridden each
method until things blow up.
