### PR TITLE
Fix deprecated OpenSSL::Digest::Digest

### DIFF
--- a/lib/aws/plugins/glacier_checksums.rb
+++ b/lib/aws/plugins/glacier_checksums.rb
@@ -56,7 +56,7 @@ module Aws
         def compute_checksums(body, &block)
 
           tree_hash = TreeHash.new
-          digest = OpenSSL::Digest::Digest.new('sha256')
+          digest = OpenSSL::Digest.new('sha256')
 
           # if the body is empty/EOF, then we should compute the
           # digests of the empty string

--- a/lib/aws/signers/base.rb
+++ b/lib/aws/signers/base.rb
@@ -11,7 +11,7 @@ module Aws
 
       def sha256_hmac(value)
         Base64.encode64(
-          OpenSSL::HMAC.digest(OpenSSL::Digest::Digest.new('sha256'),
+          OpenSSL::HMAC.digest(OpenSSL::Digest.new('sha256'),
             @credentials.secret_access_key, value)
         ).strip
       end

--- a/lib/aws/signers/s3.rb
+++ b/lib/aws/signers/s3.rb
@@ -69,7 +69,7 @@ module Aws
       end
 
       def hmac(key, value)
-        OpenSSL::HMAC.digest(OpenSSL::Digest::Digest.new('sha1'), key, value)
+        OpenSSL::HMAC.digest(OpenSSL::Digest.new('sha1'), key, value)
       end
 
       # From the S3 developer guide:

--- a/lib/aws/signers/v4.rb
+++ b/lib/aws/signers/v4.rb
@@ -119,11 +119,11 @@ module Aws
       end
 
       def hmac(key, value)
-        OpenSSL::HMAC.digest(OpenSSL::Digest::Digest.new('sha256'), key, value)
+        OpenSSL::HMAC.digest(OpenSSL::Digest.new('sha256'), key, value)
       end
 
       def hexhmac(key, value)
-        OpenSSL::HMAC.hexdigest(OpenSSL::Digest::Digest.new('sha256'), key, value)
+        OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new('sha256'), key, value)
       end
 
       private

--- a/lib/aws/tree_hash.rb
+++ b/lib/aws/tree_hash.rb
@@ -31,7 +31,7 @@ module Aws
   class TreeHash
 
     def initialize(hashes = [])
-      @digest = OpenSSL::Digest::Digest.new('sha256')
+      @digest = OpenSSL::Digest.new('sha256')
       @hashes = hashes
     end
 
@@ -49,7 +49,7 @@ module Aws
 
     def digest
       hashes = @hashes
-      digest = OpenSSL::Digest::Digest.new('sha256')
+      digest = OpenSSL::Digest.new('sha256')
       until hashes.count == 1
         hashes = hashes.each_slice(2).map do |h1,h2|
           digest.reset


### PR DESCRIPTION
Basically the same thing that was done in https://github.com/aws/aws-sdk-ruby/pull/434.
