### PR TITLE
Fix handling of empty values for required list parameters

### DIFF
--- a/lib/aws/query/builder.rb
+++ b/lib/aws/query/builder.rb
@@ -49,8 +49,12 @@ module Aws
         else
           prefix += '.member'
         end
-        values.each_with_index do |value, n|
-          member(param_list, member_shape, "#{prefix}.#{n+1}", value)
+        if values.empty? && shape.required
+          member(param_list, member_shape, prefix.split('.').first, '')
+        else
+          values.each_with_index do |value, n|
+            member(param_list, member_shape, "#{prefix}.#{n+1}", value)
+          end
         end
       end
 

--- a/spec/aws/query/builder_spec.rb
+++ b/spec/aws/query/builder_spec.rb
@@ -132,6 +132,20 @@ module Aws
             ])
           end
 
+          it 'supports empty lists for required fields' do
+            rules['members'] = {
+              'items' => {
+                'type' => 'flat_list',
+                'members' => { 'type' => 'string' },
+                'required' => true,
+                  'serialized_name' => 'PolicyNames'
+              }
+            }
+            expect(query_params(items: [])).to eq([
+              ['PolicyNames', ''],
+            ])
+          end
+
         end
 
         describe 'non-flattened lists' do
@@ -189,6 +203,20 @@ module Aws
             expect(query_params(params)).to eq([
               ['people.member.1.name', 'John'],
               ['people.member.2.name', 'Jane'],
+            ])
+          end
+
+          it 'supports empty lists for required fields' do
+            rules['members'] = {
+              'items' => {
+                'type' => 'flat_list',
+                'members' => { 'type' => 'string' },
+                'required' => true,
+                'serialized_name' => 'PolicyNames'
+              }
+            }
+            expect(query_params(items: [])).to eq([
+              ['PolicyNames', ''],
             ])
           end
 


### PR DESCRIPTION
The command `ElasticLoadBalancing#set_load_balancer_policies_of_listener` has a required parameter policy_names which is defined as a list of policy names (list of strings). The documentation for this option states:

List of policies to be associated with the listener. Currently this list can have at most one policy. If the list is empty, the current policy is removed from the listener.

If you supply an empty array for the value an exception will be thrown:

Aws::ElasticLoadBalancing::Errors::ValidationError (1 validation error detected: Value null at 'policyNames' failed to satisfy constraint: Member must not be null)

This change allows you to pass an empty array.
