### PR TITLE
Fix NameError for `412Error` on 412 without body

### DIFF
--- a/lib/aws/error_handler.rb
+++ b/lib/aws/error_handler.rb
@@ -41,6 +41,7 @@ module Aws
         400 => 'BadRequest',
         403 => 'Forbidden',
         404 => 'NotFound',
+        412 => 'PreconditionFailed',
       }[status_code] || "#{status_code}Error"
     end
 

--- a/spec/fixtures/operations/s3/412_response_head.yml
+++ b/spec/fixtures/operations/s3/412_response_head.yml
@@ -1,0 +1,10 @@
+operation: head_object
+params:
+  :bucket: 'bucket'
+  :key: 'key'
+response:
+  status_code: 412
+  body: ''
+error:
+  class: Aws::S3::Errors::PreconditionFailed
+  message: ''


### PR DESCRIPTION
```
>> Aws::S3.new.head_object(if_unmodified_since: '2014-06-09 12:44:21 +0900',
bucket: '...', key: '...')
NameError: wrong constant name 412Error
```

by the way, current implementation of `ErrorHandler#.error_code_for_empty_response` makes invalid string for constant name (ex: `412Error`)when pre-defined error constant not found, is this expected?
