### PR TITLE
Fix issue with "rake docs"

### DIFF
--- a/tasks/docs.rake
+++ b/tasks/docs.rake
@@ -30,7 +30,7 @@ end
 
 desc "Generate the API documentation."
 task :docs => ['docs:clobber', 'docs:update_readme'] do
-  sh "SOURCE=1 bundle exec yard"
+  sh({"SOURCE" => "1"}, "bundle exec yard")
 end
 
 # Generates an HTML table of supported services that is used by README.md


### PR DESCRIPTION
When I run "rake docs" I get this error:

```
rm -rf .yardoc
rm -rf api-docs
SOURCE=1 bundle exec yard
rake aborted!
Command failed with status (127): [SOURCE=1 bundle exec yard...]
tasks/docs.rake:33:in `block in <top (required)>'
Tasks: TOP => docs
(See full trace by running task with --trace)
```

With this fix I'm now able to run "rake docs" and generate documentation
locally.
