### PR TITLE
Add Aws::EC2::Instance with support for decrypting windows password

### DIFF
--- a/aws-sdk-core/lib/aws-sdk-core/ec2.rb
+++ b/aws-sdk-core/lib/aws-sdk-core/ec2.rb
@@ -5,3 +5,9 @@ Aws.add_service(:EC2, {
   resources: File.join(Aws::APIS_DIR, 'EC2.resources.json'),
   waiters: File.join(Aws::APIS_DIR, 'EC2.waiters.json'),
 })
+
+module Aws
+  module EC2
+    autoload :Instance, 'aws-sdk-core/ec2/instance'
+  end
+end

--- a/aws-sdk-core/lib/aws-sdk-core/ec2/instance.rb
+++ b/aws-sdk-core/lib/aws-sdk-core/ec2/instance.rb
@@ -1,0 +1,21 @@
+module Aws
+  module EC2
+    class Instance
+      # instance_id Provide an instance ID
+      # @option options [Client] :client Optionally provide an existing EC2 client
+      def initialize(instance_id = nil, options = {})
+        @instance_id = instance_id
+        fail "Instance ID is required" if @instance_id.nil?
+        @client = options[:client] || Aws::EC2::Client.new
+      end
+
+      def decrypted_windows_password(key_pair_path)
+        password_data = client.get_password_data instance_id: instance_id
+        decoded = Base64.decode64 password_data.strip
+        pem_bytes = Pathname.new(key_pair_path).read
+        private_key = OpenSSL::PKey::RSA.new pem_bytes
+        private_key.private_decrypt decoded
+      end
+    end
+  end
+end

--- a/aws-sdk-core/spec/aws/ec2/instance_spec.rb
+++ b/aws-sdk-core/spec/aws/ec2/instance_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+
+module Aws
+  module EC2
+    describe Instance do
+      before (:each) do
+        Aws.config[:ec2] = {
+          region: 'us-east-1',
+          credentials: Credentials.new(
+            "AKIAIOSFODNN7EXAMPLE",
+            "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"),
+          retry_limit: 0
+        }
+      end
+
+      after(:each) do
+        Aws.config = {}
+      end
+
+      let(:client) { Aws::EC2::Client.new }
+
+      describe '#initialize' do
+        it 'accepts an injected EC2 client' do
+          pre = Instance.new('i-abcd1234', client: client)
+          expect(pre.class).to eq(Aws::EC2::Instance)
+        end
+
+        it 'can be constructed without a client' do
+          pre = Instance.new('i-abcd1234')
+          expect(pre.class).to eq(Aws::EC2::Instance)
+        end
+
+        it 'throws if instance ID is missing' do
+          expect { Instance.new }.to raise_error(RuntimeError)
+        end
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
This is incomplete, but attempts to fix #122 with the best sort of documentation; none.

Note: not sure what those inline credentials provide, so making no attempt to use them to create resources to test against - please give me a steer?
