### PR TITLE
Added SQS::Message batch delete operation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,18 @@
 Next Release (TBD)
 ------------------
 
+* Feature - SQS Batch Message Delete - `Aws::SQS::Message` objects can
+  now be deleted in batches. See #141.
+
+  ```ruby
+  messages = queue.receive_messages(max_number_of_messages: 5)
+
+  # do something with messages ...
+
+  # delete the batch of messages in a single request
+  messages.delete
+  ```ruby
+
 * Feature - Queue Attributes - `Aws::SQS::Queue` now has getter methods for
   queue attributes that return type-casted values from the `#attributes`
   hash.

--- a/aws-sdk-core/apis/SQS.resources.json
+++ b/aws-sdk-core/apis/SQS.resources.json
@@ -169,6 +169,18 @@
             ]
           }
         }
+      },
+      "batchActions": {
+        "Delete": {
+          "request": {
+            "operation":"DeleteMessageBatch",
+            "params": [
+              { "target":"QueueUrl", "sourceType":"identifier", "source":"QueueUrl" },
+              { "target":"Entries[n].Id", "sourceType":"dataMember", "source":"MessageId" },
+              { "target":"Entries[n].ReceiptHandle", "sourceType":"identifier", "source":"ReceiptHandle" }
+            ]
+          }
+        }
       }
     }
   }

--- a/aws-sdk-resources/lib/aws-sdk-resources/request_params.rb
+++ b/aws-sdk-resources/lib/aws-sdk-resources/request_params.rb
@@ -26,9 +26,9 @@ module Aws
 
         def computed_params(options)
           params_hash = {}
-          Array(options[:resource]).each do |resource|
+          Array(options[:resource]).each.with_index do |resource, n|
             @params.each do |param|
-              param.apply(params_hash, options.merge(resource: resource))
+              param.apply(params_hash, options.merge(resource: resource, n: n))
             end
           end
           params_hash
@@ -55,9 +55,10 @@ module Aws
         def initialize(target)
           @target = target.to_s
           @steps = []
-          @target.scan(/\w+|\[\]/) do |step|
+          @target.scan(/\w+|\[\]|\[n\]|\[[0-9]+\]/) do |step|
             case step
-            when /\d+/ then @steps += [:array, step.to_i]
+            when /\[\d+\]/ then @steps += [:array, step[1..-2].to_i]
+            when /\[n\]/ then @steps += [:array, :n]
             when '[]' then @steps += [:array, -1]
             else @steps += [:hash, step.to_sym]
             end
@@ -72,23 +73,25 @@ module Aws
         # @param [Hash] params
         # @param [Object] value
         # @return [Hash] Returns the modified params hash.
-        def apply(params, value)
+        def apply(params, value, n = nil)
           if @final == -1
-            build_context(params) << value
+            build_context(params, n) << value
           else
-            build_context(params)[@final] = value
+            build_context(params, n)[@final] = value
           end
           params
         end
 
         private
 
-        def build_context(params)
+        def build_context(params, n)
           @steps.each_slice(2).inject(params) do |context, (key, type)|
             entry = type == :array ? [] : {}
             if key == -1
               context << entry
               entry
+            elsif key == :n
+              context[n] ||= entry
             else
               context[key] ||= entry
             end
@@ -113,7 +116,7 @@ module Aws
         # @option [requried, Resource] :resource
         def apply(params_hash, options)
           value = options[:resource].identifiers[identifier_name]
-          super(params_hash, value)
+          super(params_hash, value, options[:n])
         end
 
         # @api private
@@ -139,7 +142,7 @@ module Aws
         # @option [requried, Resource] :resource
         def apply(params_hash, options)
           value = options[:resource].data[member_name.to_sym]
-          super(params_hash, value)
+          super(params_hash, value, options[:n])
         end
 
         # @api private
@@ -163,7 +166,7 @@ module Aws
 
         # @param [Hash] params_hash
         def apply(params_hash, options = {})
-          super(params_hash, value)
+          super(params_hash, value, options[:n])
         end
 
         # @api private
@@ -187,7 +190,7 @@ module Aws
 
         # @param [Hash] params_hash
         def apply(params_hash, options = {})
-          super(params_hash, value)
+          super(params_hash, value, options[:n])
         end
 
         # @api private
@@ -211,7 +214,7 @@ module Aws
 
         # @param [Hash] params_hash
         def apply(params_hash, options = {})
-          super(params_hash, value)
+          super(params_hash, value, options[:n])
         end
 
         # @api private

--- a/aws-sdk-resources/spec/request_params_spec.rb
+++ b/aws-sdk-resources/spec/request_params_spec.rb
@@ -53,6 +53,25 @@ module Aws
           expect(params).to eq(params:[{name:'n1', values:['v1','v2']},{name:'n2', values:['v3','v4']}])
         end
 
+        it 'supports grouped params' do
+          params = {}
+          param_list = [
+            RequestParams::Base.new('entries[n].id'),
+            RequestParams::Base.new('entries[n].value')
+          ]
+          3.times do |n|
+            param_list[0].apply(params, "id-#{n+1}", n)
+            param_list[1].apply(params, "value-#{n+1}", n)
+          end
+          expect(params).to eq({
+            entries: [
+              { id: 'id-1', value: 'value-1' },
+              { id: 'id-2', value: 'value-2' },
+              { id: 'id-3', value: 'value-3' },
+            ]
+          })
+        end
+
       end
 
       describe RequestParams::Identifier do


### PR DESCRIPTION
You can now receive and delete messages in batches. This is much more efficient than deleting the messages one at a time.

``` ruby
messages = queue.receive_messages(max_number_of_messages: 5)
# do something with messages ...

# delete the batch of messages, makes 1 request
messages.delete

# delete messages one at a time, makes n requests
messages.each(&:delete)
```
