### PR TITLE
Removed logic for following 301 moved perm redirects.

### DIFF
--- a/aws-sdk-core/spec/aws/s3/client/region_detection_spec.rb
+++ b/aws-sdk-core/spec/aws/s3/client/region_detection_spec.rb
@@ -100,13 +100,6 @@ S3 client configured for "us-east-1" but the bucket "bucket" is in "eu-central-1
 
         end
 
-        it 'detects the moved permanently and redirects' do
-          client = S3::Client.new(client_opts.merge(region: 'us-west-2'))
-          resp = client.put_object(bucket:'bucket', key:'key', body:'body')
-          host = resp.context.http_request.endpoint.host
-          expect(host).to eq('bucket.s3.eu-central-1.amazonaws.com')
-        end
-
       end
 
       describe 'accessing eu-central-1 bucket using classic endpoitn and wrong sigv4 region' do


### PR DESCRIPTION
A recent commit caused `S3::Client` to attempt to follow 301 redirects. Unfortunately, it was unable to get 307 temporary redirects for all buckets, causing it to raise an runtime error. This backs out that change, while leaving the logic for upgrading to v4 for S3 'eu-central-1' buckets.
