### PR TITLE
Add `console` rake task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -38,3 +38,15 @@ begin
   Coveralls::RakeTask.new
 rescue LoadError
 end
+
+desc 'Open a console with aws-sdk loaded'
+task :console do
+  begin
+    require 'pry'
+    Pry.start
+  rescue LoadError
+    require 'irb'
+    ARGV.clear
+    IRB.start
+  end
+end


### PR DESCRIPTION
A convenient way to open a REPL with the current directory’s aws-sdk
library loaded (relying on the [load path setup at the top of the Rakefile](https://github.com/aws/aws-sdk-core-ruby/blob/c89b3d31427422d5d6d196b7c150fa82d52f020f/Rakefile#L1-L15)).

Use `pry` if available, and fall back to `irb`.

Example:
```
$ rake console
[1] pry(main)> Aws::VERSION
=> "2.0.21"

# IRB (pry is not installed)
$ rake console
irb(main):001:0> Aws::VERSION
=> "2.0.21"
```

@trevorrowe not sure how widely useful this is...but it's a big part of my dev workflow.

:neckbeard: + :shower: + :necktie: = :bowtie: 